### PR TITLE
Packaging Clean-up

### DIFF
--- a/icons/edgar.desktop
+++ b/icons/edgar.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Type=Application
 Name=The Legend of Edgar
 GenericName=2D platform game
@@ -7,4 +6,5 @@ Comment=A 2D platform game with a persistent world
 Icon=edgar
 Exec=edgar
 Terminal=false
-Categories=Game;ArcadeGame;AdventureGame;
+Categories=Game;ActionGame;AdventureGame;
+Keywords=game;action;adventure;platformer;

--- a/makefile
+++ b/makefile
@@ -41,7 +41,6 @@ endif
 CFLAGS += -Wall -pedantic
 ifeq ($(DEV),1)
 CFLAGS += -Werror -g
-NO_PAK = 1
 endif
 
 DEFINES = -DVERSION=$(VERSION) -DRELEASE=$(RELEASE) -DDEV=$(DEV) -DINSTALL_PATH=\"$(DATA_DIR)\" -DLOCALE_DIR=\"$(LOCALE_DIR)\" -DUNIX=$(UNIX)

--- a/makefile
+++ b/makefile
@@ -22,8 +22,6 @@ PO_PROG   = po_creator
 TILE_PROG = tile_creator
 endif
 
-CC       = gcc
-
 PREFIX = $(DESTDIR)/usr
 BIN_DIR = $(PREFIX)/games/
 DOC_DIR = $(PREFIX)/share/doc/$(PROG)/
@@ -40,14 +38,18 @@ else
 DATA_DIR = $(PREFIX)/share/games/edgar/
 endif
 
+CFLAGS += -Wall -pedantic
 ifeq ($(DEV),1)
-CFLAGS ?= -Wall -Werror -g -pedantic
-else
-CFLAGS ?= -Wall -pedantic
+CFLAGS += -Werror -g
+NO_PAK = 1
 endif
-DEFINES = -DVERSION=$(VERSION) -DRELEASE=$(RELEASE) -DDEV=$(DEV) -DINSTALL_PATH=\"$(DATA_DIR)\" -DLOCALE_DIR=\"$(LOCALE_DIR)\" -DPAK_FILE=\"$(PAK_FILE)\" -DUNIX=$(UNIX)
 
-LFLAGS = $(LDFLAGS) `sdl-config --libs` -lSDL -lSDL_image -lSDL_mixer -lSDL_ttf -lz -lm
+DEFINES = -DVERSION=$(VERSION) -DRELEASE=$(RELEASE) -DDEV=$(DEV) -DINSTALL_PATH=\"$(DATA_DIR)\" -DLOCALE_DIR=\"$(LOCALE_DIR)\" -DUNIX=$(UNIX)
+ifndef NO_PAK
+DEFINES += -DPAK_FILE=\"$(PAK_FILE)\"
+endif
+
+LDFLAGS += `sdl-config --libs` -lSDL -lSDL_image -lSDL_mixer -lSDL_ttf -lz -lm
 
 TILE_OBJS  = tile_creator.o save_png.o
 PAK_OBJS   = pak_creator.o
@@ -105,7 +107,7 @@ makefile.dep : src/*/*.h src/*.h
 	for i in src/*.c src/*/*.c; do $(CC) -MM "$${i}"; done > $@
 
 # compiling other source files.
-%.o:
+$(MAIN_OBJS) $(CORE_OBJS) $(EDIT_OBJS) $(TITLE_OBJS) $(PAK_OBJS) $(PO_OBJS):
 	$(CC) $(CFLAGS) $(DEFINES) -c -s $<
 
 %.mo: %.po
@@ -113,39 +115,43 @@ makefile.dep : src/*/*.h src/*.h
 
 # linking the program.
 $(PROG): $(MAIN_OBJS) $(CORE_OBJS)
-	$(CC) $(MAIN_OBJS) $(CORE_OBJS) -o $(PROG) $(LFLAGS)
+	$(CC) $(MAIN_OBJS) $(CORE_OBJS) -o $(PROG) $(LDFLAGS)
 
 # linking the program.
 $(ED_PROG): $(EDIT_OBJS) $(CORE_OBJS)
-	$(CC) $(EDIT_OBJS) $(CORE_OBJS) -o $(ED_PROG) $(LFLAGS)
+	$(CC) $(EDIT_OBJS) $(CORE_OBJS) -o $(ED_PROG) $(LDFLAGS)
 
 # linking the program.
 $(PAK_PROG): $(PAK_OBJS)
-	$(CC) $(PAK_OBJS) -o $(PAK_PROG) $(LFLAGS)
+	$(CC) $(PAK_OBJS) -o $(PAK_PROG) $(LDFLAGS)
 
 # linking the program.
 $(PO_PROG): $(PO_OBJS)
-	$(CC) $(PO_OBJS) -o $(PO_PROG) $(LFLAGS)
+	$(CC) $(PO_OBJS) -o $(PO_PROG) $(LDFLAGS)
 
 # linking the program.
 $(TILE_PROG): $(TILE_OBJS)
-	$(CC) $(TILE_OBJS) -o $(TILE_PROG) $(LFLAGS) -lpng
+	$(CC) $(TILE_OBJS) -o $(TILE_PROG) $(LDFLAGS) -lpng
 
 # cleaning everything that can be automatically recreated with "make".
 clean:
 	$(RM) $(PROG) $(ED_PROG) $(PAK_PROG) $(PO_PROG) $(TILE_PROG) $(PAK_FILE) $(LOCALE_MO) $(TILE_PROG) *.o makefile.dep
 
 buildpak: $(PAK_PROG)
+ifndef NO_PAK
 	./$(PAK_PROG) data gfx music sound font $(PAK_FILE)
 	./$(PAK_PROG) -test $(PAK_FILE)
+endif
 
 # install
 install: all
 ifeq ($(DEV),1)
 	echo Cannot install if DEV is set to 1!
 else
+ifndef NO_PAK
 	./$(PAK_PROG) data gfx music sound font $(PAK_FILE)
 	./$(PAK_PROG) -test $(PAK_FILE)
+endif
 
 	mkdir -p $(BIN_DIR)
 	mkdir -p $(DATA_DIR)
@@ -159,7 +165,9 @@ else
 	mkdir -p $(MAN_DIR)
 
 	cp $(PROG) $(BIN_DIR)$(PROG)
+ifndef NO_PAK
 	cp $(PAK_FILE) $(DATA_DIR)$(PAK_FILE)
+endif
 	cp $(DOCS) $(DOC_DIR)
 	cp $(ICONS)16x16.png $(ICON_DIR)16x16/apps/$(PROG).png
 	cp $(ICONS)32x32.png $(ICON_DIR)32x32/apps/$(PROG).png

--- a/man/edgar.6
+++ b/man/edgar.6
@@ -1,33 +1,61 @@
-.\" Manpage for edgar.
-.\" Contact riksweeney@users.sourceforge.net to correct errors or typos.
-.TH man 8 "15 Nov 2014" "1.0" "edgar man page"
+.TH EDGAR 6 "October 2015" "edgar" "The Legend of Edgar"
+
 .SH NAME
-edgar \- A platform game with a persistent world.
+edgar - A 2D platform game with a persistent world.
+
 .SH SYNOPSIS
-edgar
+.B edgar
+[\fIOPTION\fR]
+
 .SH DESCRIPTION
-The Legend of Edgar is a platform game, not unlike those found on the Amiga and SNES. Edgar must battle his way across the world, solving puzzles and defeating powerful enemies to achieve his quest.
+The Legend of Edgar is a platform game, not unlike those found on the Amiga
+and SNES. Edgar must battle his way across the world, solving puzzles and
+defeating powerful enemies to achieve his quest.
+
+When Edgar's father fails to return home after venturing out one dark and
+stormy night, Edgar fears the worst: he has been captured by the evil
+sorcerer who lives in a fortress beyond the forbidden swamp.
+
+Donning his armour, Edgar sets off to rescue him, but his quest will not be
+easy...
+
 .SH OPTIONS
-edgar takes the following command line options
-.PP
--record <filename>: Captures keyboard input
-.PP
--playback <filename>: Replays keyboard input
-.PP
--load <save_slot>: Loads the game in slot <save_slot>. Slots start at 0
-.PP
--nojoystick: Disables the joystick
-.PP
--joystick <joystick_slot>: Use joystick <joystick_slot>. Slots start at 0
-.PP
--showcredits: Shows the end credits
-.PP
--language <language_code>: Use language <language_code>. e.g. en_US, es, pl
-.SH EXAMPLES
-edgar -joystick 1 -language ru
-.PP
-This will run the game in Russian and will use control from second joystick plugged into the system
-.SH BUGS
-No major bugs.
+
+.TP
+.BI \-record\  filename
+Captures keyboard input.
+
+.TP
+.BI \-playback\  filename
+Replays captured keyboard input.
+
+.TP
+.BI \-load\  slot
+Loads the game in \fIslot\fR. Slots begin at 0.
+
+.TP
+.B -nojoystick
+Disables the joystick.
+
+.TP
+.BI \-joystick\  slot
+Use the joystick in slot \fIslot\fR. Slots begin at 0.
+
+.TP
+.B -showcredits
+Show the end credits.
+
+.TP
+.BI \-language\  language
+Use language code \fIlanguage\fR. e.g. en_US, es, pl
+
+.TP
+.BR \-h ", " \-help
+Display help screen.
+
+.SH MORE INFO
+The Legend of Edgar gameplay manual can be found in
+</usr/share/doc/edgar/index.html>.
+
 .SH AUTHOR
-Richard Sweeney (riksweeney@hotmail.com)
+Written by Richard Sweeney <riksweeney@hotmail.com>.

--- a/src/enemy/ceiling_crawler.c
+++ b/src/enemy/ceiling_crawler.c
@@ -290,7 +290,7 @@ static void fireShot()
 
 	e->flags |= FLY;
 
-	e->y += !(self->flags & FLY) > 0 ? 5 : (self->h - 5);
+	e->y += !(self->flags & FLY) ? 5 : (self->h - 5);
 
 	e->type = ENEMY;
 

--- a/src/system/pak.c
+++ b/src/system/pak.c
@@ -31,7 +31,7 @@ static int32_t fileCount;
 
 void initPakFile()
 {
-        #ifdef PAK_FILE
+        #if defined(PAK_FILE) && DEV == 0
 		int32_t offset;
 		FILE *fp;
 		int i;
@@ -88,7 +88,7 @@ void initPakFile()
 
 void verifyVersion()
 {
-        #ifdef PAK_FILE
+        #if defined(PAK_FILE) && DEV == 0
             char version[5];
 
             snprintf(version, sizeof(version), "%0.2f", VERSION);
@@ -168,7 +168,7 @@ Mix_Music *loadMusicFromPak(char *name)
 {
 	Mix_Music *music;
 
-	#ifndef PAK_FILE
+	#if !defined(PAK_FILE) || DEV == 1
                 char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
                 snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
 
@@ -222,11 +222,11 @@ static unsigned char *uncompressFileRW(char *name, unsigned long *size)
 {
 	unsigned char *source, *dest;
 	FILE *fp;
-	#ifdef PAK_FILE
+	#if defined(PAK_FILE) && DEV == 0
 		int i, index;
 	#endif
 
-	#ifndef PAK_FILE
+	#if !defined(PAK_FILE) || DEV == 1
                 char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
                 snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
 
@@ -332,7 +332,7 @@ static unsigned char *uncompressFile(char *name, int writeToFile)
 		showErrorAndExit("Failed to allocate a whole %d bytes for filename", MAX_PATH_LENGTH);
 	}
 
-        #ifndef PAK_FILE
+        #if !defined(PAK_FILE) || DEV == 1
                 char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
                 snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
 
@@ -465,7 +465,7 @@ int existsInPak(char *name)
 {
 	int exists;
 
-	#ifndef PAK_FILE
+	#if !defined(PAK_FILE) || DEV == 1
                 char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
                 snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
 
@@ -504,7 +504,7 @@ int existsInPak(char *name)
 
 void freePakFile()
 {
-	#ifndef PAK_FILE
+	#if defined(PAK_FILE) && DEV == 0
 		if (fileData != NULL)
 		{
 			free(fileData);

--- a/src/system/pak.c
+++ b/src/system/pak.c
@@ -31,7 +31,7 @@ static int32_t fileCount;
 
 void initPakFile()
 {
-	#if DEV == 0
+        #ifdef PAK_FILE
 		int32_t offset;
 		FILE *fp;
 		int i;
@@ -88,14 +88,16 @@ void initPakFile()
 
 void verifyVersion()
 {
-	char version[5];
+        #ifdef PAK_FILE
+            char version[5];
 
-	snprintf(version, sizeof(version), "%0.2f", VERSION);
+            snprintf(version, sizeof(version), "%0.2f", VERSION);
 
-	if (existsInPak(version) == FALSE)
-	{
-		showErrorAndExit("Game and PAK file versions do not match. Please reinstall the game.");
-	}
+                if (existsInPak(version) == FALSE)
+                {
+                        showErrorAndExit("Game and PAK file versions do not match. Please reinstall the game.");
+                }
+        #endif
 }
 
 SDL_Surface *loadImageFromPak(char *name)
@@ -166,10 +168,13 @@ Mix_Music *loadMusicFromPak(char *name)
 {
 	Mix_Music *music;
 
-	#if DEV == 1
+	#ifndef PAK_FILE
+                char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
+                snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
+
 		FILE *fp;
 
-		fp = fopen(name, "rb");
+		fp = fopen(fullName, "rb");
 
 		if (fp == NULL)
 		{
@@ -178,7 +183,7 @@ Mix_Music *loadMusicFromPak(char *name)
 
 		fclose(fp);
 
-		music = Mix_LoadMUS(name);
+		music = Mix_LoadMUS(fullName);
 
 		return music;
 	#else
@@ -217,12 +222,15 @@ static unsigned char *uncompressFileRW(char *name, unsigned long *size)
 {
 	unsigned char *source, *dest;
 	FILE *fp;
-	#if DEV != 1
+	#ifdef PAK_FILE
 		int i, index;
 	#endif
 
-	#if DEV == 1
-		fp = fopen(name, "rb");
+	#ifndef PAK_FILE
+                char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
+                snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
+
+		fp = fopen(fullName, "rb");
 
 		if (fp == NULL)
 		{
@@ -314,9 +322,6 @@ static unsigned char *uncompressFile(char *name, int writeToFile)
 	unsigned long size;
 	unsigned char *source, *dest;
 	FILE *fp;
-	#if DEV != 1
-		int i, index;
-	#endif
 
 	filename = NULL;
 
@@ -327,8 +332,11 @@ static unsigned char *uncompressFile(char *name, int writeToFile)
 		showErrorAndExit("Failed to allocate a whole %d bytes for filename", MAX_PATH_LENGTH);
 	}
 
-	#if DEV == 1
-		fp = fopen(name, "rb");
+        #ifndef PAK_FILE
+                char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
+                snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
+
+		fp = fopen(fullName, "rb");
 
 		if (fp == NULL)
 		{
@@ -355,7 +363,8 @@ static unsigned char *uncompressFile(char *name, int writeToFile)
 
 		source = NULL;
 	#else
-		index = -1;
+                int i;
+		int index = -1;
 
 		for (i=0;i<fileCount;i++)
 		{
@@ -455,14 +464,14 @@ static unsigned char *uncompressFile(char *name, int writeToFile)
 int existsInPak(char *name)
 {
 	int exists;
-	#if DEV == 1
-		FILE *fp;
-	#else
-		int i;
-	#endif
 
-	#if DEV == 1
-		fp = fopen(name, "rb");
+	#ifndef PAK_FILE
+                char fullName[MAX_PATH_LENGTH] = INSTALL_PATH;
+                snprintf(fullName, sizeof(fullName), "%s%s", INSTALL_PATH, name);
+
+		FILE *fp;
+		fp = fopen(fullName, "rb");
+
 
 		if (fp == NULL)
 		{
@@ -476,6 +485,7 @@ int existsInPak(char *name)
 			exists = TRUE;
 		}
 	#else
+                int i;
 		exists = FALSE;
 
 		for (i=0;i<fileCount;i++)
@@ -494,7 +504,7 @@ int existsInPak(char *name)
 
 void freePakFile()
 {
-	#if DEV == 0
+	#ifndef PAK_FILE
 		if (fileData != NULL)
 		{
 			free(fileData);


### PR DESCRIPTION
- Updated the manpage to follow more traditional formatting.
- Updated the desktop file to [include `Categories`](https://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry.html) and to remove the [deprecated `Encoding` key](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#deprecated-items).
- Updated `src/system/pak.c` to use the existence of `PAK_FILE` rather than `DEV`.
- Updated the makefile to remove hard-coding of `gcc`, add support for external CFLAGS and the ability to toggle the pak file (needed for packaging).

These are changes I've patched in the Debian version, but it would be great to have it in upstream to simplify the source package.
