### PR TITLE
Allow to install data files without .pak

### DIFF
--- a/makefile
+++ b/makefile
@@ -147,11 +147,7 @@ install: all
 ifeq ($(DEV),1)
 	echo Cannot install if DEV is set to 1!
 else
-ifndef NO_PAK
-	./$(PAK_PROG) data gfx music sound font $(PAK_FILE)
-	./$(PAK_PROG) -test $(PAK_FILE)
-endif
-
+	$(MAKE) buildpak
 	mkdir -p $(BIN_DIR)
 	mkdir -p $(DATA_DIR)
 	mkdir -p $(DOC_DIR)

--- a/makefile
+++ b/makefile
@@ -166,6 +166,8 @@ endif
 	cp $(PROG) $(BIN_DIR)$(PROG)
 ifndef NO_PAK
 	cp $(PAK_FILE) $(DATA_DIR)$(PAK_FILE)
+else
+	cp -a data gfx music sound font $(DATA_DIR)
 endif
 	cp $(DOCS) $(DOC_DIR)
 	cp $(ICONS)16x16.png $(ICON_DIR)16x16/apps/$(PROG).png


### PR DESCRIPTION
to make reproducible package builds easier (without PR #22).

See https://reproducible-builds.org/ for why this is good.