### PR TITLE
Fix crash when entity is freed while still being referenced by player

### DIFF
--- a/src/entity.c
+++ b/src/entity.c
@@ -38,6 +38,7 @@ Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
 #include "system/random.h"
 #include "system/resources.h"
 
+extern Entity player;
 extern Entity *self;
 extern Game game;
 
@@ -2106,6 +2107,11 @@ static int isReferenced(Entity *e)
 		{
 			return TRUE;
 		}
+	}
+
+	if (player.head == e || player.target == e || player.standingOn == e)
+	{
+		return TRUE;
 	}
 
 	return FALSE;


### PR DESCRIPTION
The game would crash at certain points when an entity was referenced by the player that had already been freed in `entity.c`. Specifically, it crashed on line 905 of `src/player.c` while trying to dereference `self->standingOn->dirX`. After some digging, I found that the entity which was currently set as `self->standingOn` had already been freed in `drawEntities` (in `src/entity.c`) because `isReferenced` was not checking if the entity was being referenced by the player. This patch should fix that. Note that I don't know if this would be the correct way to check that, but it fixed the crash for me.