### PR TITLE
Include SDL2 CFLAGS to the makefile script

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,7 +38,7 @@ else
 DATA_DIR = $(PREFIX)/share/games/edgar/
 endif
 
-CFLAGS += -Wall -pedantic
+CFLAGS += `sdl2-config --cflags` -Wall -pedantic
 ifeq ($(DEV),1)
 CFLAGS += -Werror -g
 endif


### PR DESCRIPTION
While writing an expression for Nixpkgs, it was found that the current makefile did not find the SDL headers, because they were installed in custom, non-standard locations.
This issue can be easily fixed by using sdl2-config.