### PR TITLE
Add missing CFLAGS to compiler command

### DIFF
--- a/makefile
+++ b/makefile
@@ -104,7 +104,7 @@ endif
 all : $(PROG) makefile.dep $(ED_PROG) $(PAK_PROG) $(LOCALE_MO) $(PO_PROG)
 
 makefile.dep : src/*/*.h src/*.h
-	for i in src/*.c src/*/*.c; do $(CC) -MM "$${i}"; done > $@
+	for i in src/*.c src/*/*.c; do $(CC) $(CFLAGS) -MM "$${i}"; done > $@
 
 # compiling other source files.
 $(MAIN_OBJS) $(CORE_OBJS) $(EDIT_OBJS) $(TITLE_OBJS) $(PAK_OBJS) $(PO_OBJS) $(TILE_OBJS):


### PR DESCRIPTION
In `makefile`, the `CFLAGS` were not included in the command for generating `makefile.dep`, causing a build failure on systems which have headers in non-standard places (e.g. `/usr/local/include` instead of `/usr/include`).