### PR TITLE
Fix binary stripping

### DIFF
--- a/makefile
+++ b/makefile
@@ -41,6 +41,8 @@ endif
 CFLAGS += `sdl2-config --cflags` -Wall -pedantic
 ifeq ($(DEV),1)
 CFLAGS += -Werror -g
+else
+LDFLAGS += -s
 endif
 
 DEFINES = -DVERSION=$(VERSION) -DRELEASE=$(RELEASE) -DDEV=$(DEV) -DINSTALL_PATH=\"$(DATA_DIR)\" -DLOCALE_DIR=\"$(LOCALE_DIR)\" -DUNIX=$(UNIX)
@@ -108,7 +110,7 @@ makefile.dep : src/*/*.h src/*.h
 
 # compiling other source files.
 $(MAIN_OBJS) $(CORE_OBJS) $(EDIT_OBJS) $(TITLE_OBJS) $(PAK_OBJS) $(PO_OBJS) $(TILE_OBJS):
-	$(CC) $(CFLAGS) $(DEFINES) -c -s $<
+	$(CC) $(CFLAGS) $(DEFINES) -c $<
 
 %.mo: %.po
 	msgfmt -c -o $@ $<


### PR DESCRIPTION
When compiling with `clang`, there are lots of warnings `clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]`. This appears to be because the `-s` option for stripping the binary is actually a link-time option (both in `clang` and `gcc` - `gcc` just doesn't warn about it). As far as I can tell, the option currently doesn't have any effect (this can be verified by checking that the final binary still contains all the symbols). This pull request moves the `-s` option to `LDFLAGS` and only adds it in release mode (otherwise, debug symbols would be stripped). After this change, the symbols are properly stripped from the binary in release mode. I have not tested this with any compilers other than `clang` and `gcc`, though, so I don't know how those would react to the change.