### PR TITLE
Fix compiler warnings for abs()

### DIFF
--- a/src/boss/ant_lion.c
+++ b/src/boss/ant_lion.c
@@ -157,7 +157,7 @@ static void hunt()
 
 	/* Position under the player */
 
-	if (abs(self->x - self->targetX) <= self->speed * 3)
+	if (fabsf(self->x - self->targetX) <= self->speed * 3)
 	{
 		self->dirX = 0;
 
@@ -224,7 +224,7 @@ static void trapTarget(Entity *other)
 		return;
 	}
 
-	if (abs((self->y + self->h) - (other->y + other->h)) > 5)
+	if (fabsf((self->y + self->h) - (other->y + other->h)) > 5)
 	{
 		return;
 	}

--- a/src/boss/azriel.c
+++ b/src/boss/azriel.c
@@ -567,7 +567,7 @@ static void lightningCageMoveBackToPlayer()
 
 	/* Position above the player */
 
-	if (abs(self->x - self->targetX) <= player.speed / 2)
+	if (fabsf(self->x - self->targetX) <= player.speed / 2)
 	{
 		self->action = &lightningCage;
 

--- a/src/boss/black_book_2.c
+++ b/src/boss/black_book_2.c
@@ -3295,7 +3295,7 @@ static void guardianAddSmokeAlongBody()
 
 	shakeScreen(MEDIUM, 15);
 
-	bodyLength = abs(self->endX - self->x);
+	bodyLength = fabsf(self->endX - self->x);
 
 	for (i=0;i<100;i++)
 	{
@@ -5457,7 +5457,7 @@ static void queenWaspDropInit()
 	{
 		/* Move towards player */
 
-		if (abs(self->x - self->targetX) <= self->speed)
+		if (fabsf(self->x - self->targetX) <= self->speed)
 		{
 			self->dirX = 0;
 		}

--- a/src/boss/boulder_boss.c
+++ b/src/boss/boulder_boss.c
@@ -181,7 +181,7 @@ static void chasePlayer()
 		addDust();
 	}
 
-	if (self->dirX == 0 && abs(self->endX) > 2)
+	if (self->dirX == 0 && fabsf(self->endX) > 2)
 	{
 		self->action = &idle;
 

--- a/src/boss/cave_boss.c
+++ b/src/boss/cave_boss.c
@@ -773,7 +773,7 @@ static void fireDropMoveAbovePlayer()
 		self->targetX = player.x - (self->w - self->offsetX) + player.w / 2;
 	}
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -950,7 +950,7 @@ static void ceilingBurnMoveToTop()
 		self->dirX = self->face == LEFT ? -self->speed : self->speed;
 	}
 
-	else if (abs(self->x - self->targetX) <= abs(self->dirX))
+	else if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -1163,7 +1163,7 @@ static void incinerateMoveToTop()
 		self->dirX = self->face == LEFT ? -self->speed : self->speed;
 	}
 
-	else if (abs(self->x - self->targetX) <= abs(self->dirX))
+	else if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -1543,7 +1543,7 @@ static void eggDropMove()
 {
 	Entity *e;
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -1656,7 +1656,7 @@ static void icicleDropMoveToTop()
 		self->dirX = self->face == LEFT ? -self->speed : self->speed;
 	}
 
-	else if (abs(self->x - self->targetX) <= abs(self->dirX))
+	else if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -1976,7 +1976,7 @@ static void acidStreamMoveToTop()
 		self->dirX = self->face == LEFT ? -self->speed : self->speed;
 	}
 
-	else if (abs(self->x - self->targetX) <= abs(self->dirX))
+	else if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -2080,7 +2080,7 @@ static void acidStream()
 
 static void acidStreamFinish()
 {
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/boss/centurion_boss.c
+++ b/src/boss/centurion_boss.c
@@ -1140,7 +1140,7 @@ static void followPlayer()
 
 	/* Position above the player */
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/boss/evil_edgar.c
+++ b/src/boss/evil_edgar.c
@@ -470,7 +470,7 @@ static void attackPlayer()
 
 			facePlayer();
 
-			if ((self->face == LEFT && abs(self->x - (player.x + player.w)) < 16) || (self->face == RIGHT && abs(player.x - (self->x + self->w)) < 16))
+			if ((self->face == LEFT && fabsf(self->x - (player.x + player.w)) < 16) || (self->face == RIGHT && fabsf(player.x - (self->x + self->w)) < 16))
 			{
 				setEntityAnimation(self, "STAND");
 

--- a/src/boss/fly_boss.c
+++ b/src/boss/fly_boss.c
@@ -376,7 +376,7 @@ static void dropInit()
 	{
 		/* Move towards player */
 
-		if (abs(self->x - self->targetX) <= self->speed)
+		if (fabsf(self->x - self->targetX) <= self->speed)
 		{
 			self->dirX = 0;
 		}

--- a/src/boss/gargoyle.c
+++ b/src/boss/gargoyle.c
@@ -1801,9 +1801,9 @@ static void lanceFallout()
 		if (el->entity->inUse == TRUE && el->entity->type == WEAK_WALL && el->entity->mental == -1 &&
 			el->entity->touch != NULL && el->entity->x >= startX && el->entity->x < endX)
 		{
-			if (abs(el->entity->x - self->head->x) > distance)
+			if (fabsf(el->entity->x - self->head->x) > distance)
 			{
-				distance = abs(el->entity->x - self->head->x);
+				distance = fabsf(el->entity->x - self->head->x);
 
 				checkpointX = el->entity->x;
 			}

--- a/src/boss/golem_rock_dropper.c
+++ b/src/boss/golem_rock_dropper.c
@@ -67,7 +67,7 @@ static void followPlayer()
 
 		/* Position above the player */
 
-		if (abs(self->x - self->targetX) <= abs(self->dirX))
+		if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 		{
 			self->x = self->targetX;
 

--- a/src/boss/grimlore.c
+++ b/src/boss/grimlore.c
@@ -1216,8 +1216,8 @@ static void swordDropTeleportAway()
 			showErrorAndExit("Grimlore cannot find target");
 		}
 
-		d1 = abs(player.x - t1->x);
-		d2 = abs(player.x - t2->x);
+		d1 = fabsf(player.x - t1->x);
+		d2 = fabsf(player.x - t2->x);
 
 		if (d1 < d2)
 		{
@@ -1869,7 +1869,7 @@ static void flameWait()
 	{
 		startX = self->face == LEFT ? self->endX : self->startX;
 
-		if (collision(player.x, player.y, player.w, player.h, startX, self->y, abs(self->startX - self->endX), self->h) == 1)
+		if (collision(player.x, player.y, player.w, player.h, startX, self->y, fabsf(self->startX - self->endX), self->h) == 1)
 		{
 			e = addProjectile("enemy/fireball", self->head, 0, 0, (self->face == LEFT ? -self->dirX : self->dirX), 0);
 

--- a/src/boss/mataeus_wall.c
+++ b/src/boss/mataeus_wall.c
@@ -313,7 +313,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				if (self->dirY < 0)
 				{

--- a/src/boss/phoenix.c
+++ b/src/boss/phoenix.c
@@ -291,7 +291,7 @@ static void dropAttackInit()
 
 	/* Position above the player */
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 
@@ -356,7 +356,7 @@ static void riseAttackInit()
 
 	/* Position below the player */
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/boss/snake_boss.c
+++ b/src/boss/snake_boss.c
@@ -1185,7 +1185,7 @@ static void addSmokeAlongBody()
 
 	shakeScreen(MEDIUM, 15);
 
-	bodyLength = abs(self->endX - self->x);
+	bodyLength = (int)fabsf(self->endX - self->x);
 
 	for (i=0;i<100;i++)
 	{

--- a/src/enemy/chicken.c
+++ b/src/enemy/chicken.c
@@ -182,7 +182,7 @@ static void moveToFood()
 		self->action = &wander;
 	}
 
-	else if (abs(self->x + (self->face == RIGHT ? self->w : 0) - self->target->x) > self->speed)
+	else if (fabsf(self->x + (self->face == RIGHT ? self->w : 0) - self->target->x) > self->speed)
 	{
 		self->dirX = self->target->x < self->x ? -self->speed : self->speed;
 

--- a/src/enemy/large_book.c
+++ b/src/enemy/large_book.c
@@ -2066,7 +2066,7 @@ static void followPlayer()
 		hover();
 	}
 
-	else if (abs(self->x - self->targetX) <= abs(self->dirX))
+	else if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/enemy/scanner.c
+++ b/src/enemy/scanner.c
@@ -262,7 +262,7 @@ static void followPlayer()
 	{
 		/* Position under the player */
 
-		if (abs(self->x - self->targetX) <= self->speed * 3)
+		if (fabsf(self->x - self->targetX) <= self->speed * 3)
 		{
 			self->dirX = 0;
 		}

--- a/src/enemy/skeleton.c
+++ b/src/enemy/skeleton.c
@@ -487,7 +487,7 @@ static void attackPlayer()
 
 	facePlayer();
 
-	if ((self->face == LEFT && abs(self->x - (player.x + player.w)) < 24) || (self->face == RIGHT && abs(player.x - (self->x + self->w)) < 24))
+	if ((self->face == LEFT && fabsf(self->x - (player.x + player.w)) < 24) || (self->face == RIGHT && fabsf(player.x - (self->x + self->w)) < 24))
 	{
 		setEntityAnimation(self, "STAND");
 

--- a/src/enemy/spider.c
+++ b/src/enemy/spider.c
@@ -192,7 +192,7 @@ static void redTakeDamage(Entity *other, int damage)
 
 static void retreat()
 {
-	if (abs(self->y - self->targetY) <= self->speed * 3)
+	if (fabsf(self->y - self->targetY) <= self->speed * 3)
 	{
 		self->y = self->targetY;
 	}
@@ -247,7 +247,7 @@ static void move()
 
 	else
 	{
-		if (abs(self->y - self->targetY) > self->speed)
+		if (fabsf(self->y - self->targetY) > self->speed)
 		{
 			self->dirY = (self->y < self->targetY ? self->speed * 5 : -self->speed);
 		}

--- a/src/enemy/thunder_cloud.c
+++ b/src/enemy/thunder_cloud.c
@@ -78,7 +78,7 @@ static void followPlayer()
 
 	/* Position above the player */
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/enemy/wasp.c
+++ b/src/enemy/wasp.c
@@ -87,7 +87,7 @@ static void flyToTarget()
 
 	self->dirY = cos(DEG_TO_RAD(self->thinkTime));
 
-	if (abs(self->x - self->targetX) > self->speed)
+	if (fabsf(self->x - self->targetX) > self->speed)
 	{
 		self->dirX = (self->x < self->targetX ? self->speed : -self->speed);
 	}

--- a/src/enemy/whirlwind.c
+++ b/src/enemy/whirlwind.c
@@ -165,7 +165,7 @@ static void suckIn()
 {
 	Entity *e;
 
-	if (fabs(self->target->x - self->targetX) > fabs(4))
+	if (fabs(self->target->x - self->targetX) > 4)
 	{
 		self->target->x += self->target->x > self->targetX ? -4 : 4;
 

--- a/src/entity.c
+++ b/src/entity.c
@@ -1663,7 +1663,7 @@ static void scriptEntityMoveToTarget()
 		showErrorAndExit("%s has a speed of 0 and will not move!", self->objectiveName);
 	}
 
-	if (abs(self->x - self->targetX) > self->speed)
+	if (fabsf(self->x - self->targetX) > self->speed)
 	{
 		self->dirX = (self->x < self->targetX ? self->speed : -self->speed);
 	}
@@ -1678,7 +1678,7 @@ static void scriptEntityMoveToTarget()
 		self->targetY = self->y;
 	}
 
-	if (abs(self->y - self->targetY) > self->speed)
+	if (fabsf(self->y - self->targetY) > self->speed)
 	{
 		self->dirY = (self->y < self->targetY ? self->speed : -self->speed);
 	}
@@ -1743,7 +1743,7 @@ static void entityMoveToTarget()
 		showErrorAndExit("%s has a speed of 0 and will not move!", self->objectiveName);
 	}
 
-	if (abs(self->x - self->targetX) > self->speed)
+	if (fabsf(self->x - self->targetX) > self->speed)
 	{
 		self->dirX = (self->x < self->targetX ? self->speed : -self->speed);
 	}
@@ -1760,7 +1760,7 @@ static void entityMoveToTarget()
 		self->targetY = self->y;
 	}
 
-	if (abs(self->y - self->targetY) > self->speed)
+	if (fabsf(self->y - self->targetY) > self->speed)
 	{
 		self->dirY = (self->y < self->targetY ? self->speed : -self->speed);
 	}
@@ -1840,7 +1840,7 @@ void doTeleport()
 	float speed;
 	Entity *e;
 
-	if (abs(self->x - self->targetX) < TELEPORT_SPEED && abs(self->y - self->targetY) < TELEPORT_SPEED)
+	if (fabsf(self->x - self->targetX) < TELEPORT_SPEED && fabsf(self->y - self->targetY) < TELEPORT_SPEED)
 	{
 		self->flags &= ~(NO_DRAW|HELPLESS|TELEPORTING);
 

--- a/src/item/apple_tree.c
+++ b/src/item/apple_tree.c
@@ -211,7 +211,7 @@ static void appleWait()
 	{
 		self->x += self->dirX;
 
-		if (abs(self->startX - self->x) > 1)
+		if (fabsf(self->startX - self->x) > 1)
 		{
 			self->dirX *= -1;
 		}

--- a/src/item/cloud_geyzer.c
+++ b/src/item/cloud_geyzer.c
@@ -150,7 +150,7 @@ static void cloudTouch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				/* Place the player as close to the solid tile as possible */
 

--- a/src/item/high_striker.c
+++ b/src/item/high_striker.c
@@ -140,7 +140,7 @@ static void touch(Entity *other)
 
 		dirY *= 14;
 
-		if (abs(dirY) > self->maxHealth && self->maxThinkTime == 0)
+		if (fabsf(dirY) > self->maxHealth && self->maxThinkTime == 0)
 		{
 			self->maxHealth = dirY > 14 ? 14 : dirY;
 

--- a/src/item/lab_crusher.c
+++ b/src/item/lab_crusher.c
@@ -99,7 +99,7 @@ static void followTarget()
 
 		/* Position above the player */
 
-		if (abs(self->x - self->targetX) <= abs(self->dirX))
+		if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 		{
 			self->x = self->targetX;
 
@@ -261,7 +261,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				if (self->dirY < 0)
 				{

--- a/src/item/magnet.c
+++ b/src/item/magnet.c
@@ -149,7 +149,7 @@ static void touch(Entity *other)
 {
 	if (self->active == TRUE && self->target == NULL && strcmpignorecase(other->name, self->objectiveName) == 0)
 	{
-		if (abs(other->x - self->x - self->w / 2 + other->w / 2) <= 4)
+		if (fabsf(other->x - self->x - self->w / 2 + other->w / 2) <= 4)
 		{
 			self->target = other;
 

--- a/src/item/rock_container.c
+++ b/src/item/rock_container.c
@@ -97,7 +97,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				/* Place the player as close to the solid tile as possible */
 

--- a/src/item/scale.c
+++ b/src/item/scale.c
@@ -164,7 +164,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				/* Place the player as close to the solid tile as possible */
 

--- a/src/item/skull.c
+++ b/src/item/skull.c
@@ -188,7 +188,7 @@ static void followPlayer()
 
 	/* Position above the player */
 
-	if (abs(self->x - self->targetX) <= abs(self->dirX))
+	if (fabsf(self->x - self->targetX) <= fabsf(self->dirX))
 	{
 		self->x = self->targetX;
 

--- a/src/item/train.c
+++ b/src/item/train.c
@@ -74,7 +74,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				if (self->dirY < 0)
 				{

--- a/src/map.c
+++ b/src/map.c
@@ -987,7 +987,7 @@ void centerEntityOnMap()
 		}
 	}
 
-	if (abs(map.cameraX - map.startX) > speed)
+	if (fabsf(map.cameraX - map.startX) > speed)
 	{
 		map.cameraX += map.cameraX < map.startX ? speed : -speed;
 	}
@@ -997,7 +997,7 @@ void centerEntityOnMap()
 		map.cameraX = map.startX;
 	}
 
-	if (abs(map.cameraY - map.startY) > speed)
+	if (fabsf(map.cameraY - map.startY) > speed)
 	{
 		if (map.cameraY < map.startY)
 		{

--- a/src/world/conveyor_belt.c
+++ b/src/world/conveyor_belt.c
@@ -79,14 +79,14 @@ static void entityWait()
 			{
 				self->dirX = self->face == LEFT ? -fabs(self->speed) : self->speed;
 
-				self->frameSpeed = abs(self->frameSpeed);
+				self->frameSpeed = fabsf(self->frameSpeed);
 			}
 
 			else
 			{
 				self->dirX = self->face == RIGHT ? -fabs(self->speed) : self->speed;
 
-				self->frameSpeed = -abs(self->frameSpeed);
+				self->frameSpeed = -fabsf(self->frameSpeed);
 			}
 		}
 
@@ -119,14 +119,14 @@ static void init()
 		{
 			self->dirX = self->face == LEFT ? -fabs(self->speed) : self->speed;
 
-			self->frameSpeed = abs(self->frameSpeed);
+			self->frameSpeed = fabsf(self->frameSpeed);
 		}
 
 		else
 		{
 			self->dirX = self->face == RIGHT ? -fabs(self->speed) : self->speed;
 
-			self->frameSpeed = -abs(self->frameSpeed);
+			self->frameSpeed = -fabsf(self->frameSpeed);
 		}
 	}
 

--- a/src/world/door.c
+++ b/src/world/door.c
@@ -138,7 +138,7 @@ static void moveToTarget()
 		self->targetY = self->active == TRUE ? self->endY : self->startY;
 	}
 
-	if (abs(self->x - self->targetX) > self->speed)
+	if (fabsf(self->x - self->targetX) > self->speed)
 	{
 		self->dirX = (self->x < self->targetX ? self->speed : -self->speed);
 	}
@@ -148,7 +148,7 @@ static void moveToTarget()
 		self->x = self->targetX;
 	}
 
-	if (abs(self->y - self->targetY) > self->speed)
+	if (fabsf(self->y - self->targetY) > self->speed)
 	{
 		self->dirY = (self->y < self->targetY ? self->speed : -self->speed);
 	}

--- a/src/world/lift.c
+++ b/src/world/lift.c
@@ -106,7 +106,7 @@ static void touch(Entity *other)
 		{
 			bottomBefore = other->y + other->h - other->dirY - 1;
 
-			if (abs(bottomBefore - self->y) < self->h - 1)
+			if (fabsf(bottomBefore - self->y) < self->h - 1)
 			{
 				if (self->dirY < 0)
 				{
@@ -231,7 +231,7 @@ static void moveToTarget()
 
 	if (self->active == TRUE || self->type == MANUAL_LIFT)
 	{
-		if (abs(self->x - self->targetX) > self->speed)
+		if (fabsf(self->x - self->targetX) > self->speed)
 		{
 			self->dirX = (self->x < self->targetX ? self->speed : -self->speed);
 		}
@@ -241,7 +241,7 @@ static void moveToTarget()
 			self->x = self->targetX;
 		}
 
-		if (abs(self->y - self->targetY) > self->speed)
+		if (fabsf(self->y - self->targetY) > self->speed)
 		{
 			self->dirY = (self->y < self->targetY ? self->speed : -self->speed);
 		}

--- a/src/world/line_def.c
+++ b/src/world/line_def.c
@@ -109,8 +109,8 @@ static void initialise()
 	self->x = self->startX;
 	self->y = self->startY;
 
-	self->w = abs(self->startX - self->endX) + 1;
-	self->h = abs(self->startY - self->endY) + 1;
+	self->w = fabsf(self->startX - self->endX) + 1;
+	self->h = fabsf(self->startY - self->endY) + 1;
 
 	self->box.x = 0;
 	self->box.y = 0;


### PR DESCRIPTION
When compiling with clang, there are a lot of warnings `warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]` because `abs` is used with floating-point values in many places. This isn't really a problem since the values are just automatically casted to `int` before the function is called, but the warnings are annoying. There are two ways to fix them: One way is to just cast all the `float`s to `int` to make the warnings go away. The other way is to replace `abs` with `fabsf`. I used the latter option in this pull request, but I'm wondering if maybe the first way would be better. The problem is that it seems as if `fabsf` would be a better fit in most places, but using it does change the behavior very slightly since the values aren't rounded down anymore, so perhaps bugs could crop up somewhere. What's your opinion on this? If you want, I can just add a bunch of casts so the warnings go away, but the behavior isn't changed at all.