### PR TITLE
src/dialog.c: fix the crash under _FORTIFY_SOURCE=2

### DIFF
--- a/src/dialog.c
+++ b/src/dialog.c
@@ -385,7 +385,7 @@ static char *replaceString(char *string, char *find, char *replace)
 
 	buffer[p - string] = '\0';
 
-	SNPRINTF(buffer + (p - string), MAX_VALUE_LENGTH, "%s%s", replace, p + strlen(find));
+	SNPRINTF(buffer + (p - string), MAX_VALUE_LENGTH - (p - string), "%s%s", replace, p + strlen(find));
 
 	return buffer;
 }


### PR DESCRIPTION
Without the change the first startup crashes `edgar` as:

    $ gdb --args ./result/bin/edgar
    Reading symbols from ./result/bin/edgar...
    (gdb) run
    ...
    Production Version
    *** buffer overflow detected ***: terminated
    ...
    Thread 1 "edgar" received signal SIGABRT, Aborted.
    0x00007ffff78988ec in __pthread_kill_implementation () from ...-glibc-2.40-36/lib/libc.so.6
    (gdb) bt
    #0  0x00007ffff78988ec in __pthread_kill_implementation () from ...-glibc-2.40-36/lib/libc.so.6
    #1  0x00007ffff78409c6 in raise () from ...-glibc-2.40-36/lib/libc.so.6
    #2  0x00007ffff7828938 in abort () from ...-glibc-2.40-36/lib/libc.so.6
    #3  0x00007ffff782978b in __libc_message_impl.cold () from ...-glibc-2.40-36/lib/libc.so.6
    #4  0x00007ffff7927149 in __fortify_fail () from ..-glibc-2.40-36/lib/libc.so.6
    #5  0x00007ffff7926a54 in __chk_fail () from ..-glibc-2.40-36/lib/libc.so.6
    #6  0x00007ffff7928435 in __snprintf_chk () from ...-glibc-2.40-36/lib/libc.so.6
    #7  0x00000000004330ea in snprintf (__s=0xb40281 <buffer+1> "", __n=80, __fmt=0x4e5878 "%s%s") at ...-glibc-2.40-36-dev/include/bits/stdio2.h:68
    #8  replaceString (string=string@entry=0xbe4cdc "([INPUT_ATTACK]),", find=find@entry=0x4e58d9 "[INPUT_ATTACK]", replace=0x5573a0 <text> "Left Ctrl") at src/dialog.c:388
    #9  0x00000000004337d6 in createDialogBox (title=<optimized out>,
        msg=msg@entry=0x7fffffffc85e "You can also move to the next dialog box by pressing Attack ([INPUT_ATTACK]), Block ([INPUT_BLOCK]), Jump ([INPUT_JUMP]), Action ([INPUT_INTERACT]) or Use Item ([INPUT_ACTIVATE])") at src/dialog.c:223
    #10 0x0000000000433b8b in createDialogBoxFromScript (msg=<optimized out>) at src/dialog.c:45
    #11 0x0000000000433f0a in readNextScriptLine () at src/event/script.c:269
    #12 0x000000000041900d in dialogWait () at src/player.c:884
    #13 0x000000000041cdc9 in doPlayer () at src/player.c:778
    #14 0x00000000004053dd in main (argc=<optimized out>, argv=0x7fffffffce48) at src/main.c:322

This happens because target buffer size is statically known to be smaller than buffer size passed to `snprintf()`. The change adjusts the buffer size.

Closes: https://github.com/riksweeney/edgar/issues/65