### PR TITLE
Add support for cross-compilation

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,6 +8,8 @@ MAN = man/
 UNIX = 1
 MACOS = 0
 
+PKG_CONFIG ?= pkg-config
+
 ifeq ($(UNIX),0)
 PROG      = edgar.exe
 ED_PROG   = mapeditor.exe
@@ -38,7 +40,7 @@ else
 DATA_DIR = $(PREFIX)/share/games/edgar/
 endif
 
-CFLAGS += `sdl2-config --cflags` -Wall -pedantic
+CFLAGS += `$(PKG_CONFIG) --cflags sdl2 SDL2_mixer SDL2_image SDL2_ttf zlib libpng` -Wall -pedantic
 ifeq ($(DEV),1)
 CFLAGS += -Werror -g
 else
@@ -50,7 +52,7 @@ ifndef NO_PAK
 DEFINES += -DPAK_FILE=\"$(PAK_FILE)\"
 endif
 
-LDFLAGS += `sdl2-config --libs` -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lz -lm -lpng
+LDFLAGS += `$(PKG_CONFIG) --libs sdl2 SDL2_mixer SDL2_image SDL2_ttf zlib libpng` -lm
 
 TILE_OBJS  = tile_creator.o
 PAK_OBJS   = pak_creator.o

--- a/makefile
+++ b/makefile
@@ -10,6 +10,11 @@ MACOS = 0
 
 PKG_CONFIG ?= pkg-config
 
+BUILD_CC := $(CC)
+BUILD_CFLAGS := $(CFLAGS)
+BUILD_LDFLAGS := $(LDFLAGS)
+BUILD_PKG_CONFIG := $(PKG_CONFIG)
+
 ifeq ($(UNIX),0)
 PROG      = edgar.exe
 ED_PROG   = mapeditor.exe
@@ -41,6 +46,7 @@ DATA_DIR = $(PREFIX)/share/games/edgar/
 endif
 
 CFLAGS += `$(PKG_CONFIG) --cflags sdl2 SDL2_mixer SDL2_image SDL2_ttf zlib libpng` -Wall -pedantic
+BUILD_CFLAGS += `$(BUILD_PKG_CONFIG) --cflags zlib`
 ifeq ($(DEV),1)
 CFLAGS += -Werror -g
 else
@@ -53,6 +59,7 @@ DEFINES += -DPAK_FILE=\"$(PAK_FILE)\"
 endif
 
 LDFLAGS += `$(PKG_CONFIG) --libs sdl2 SDL2_mixer SDL2_image SDL2_ttf zlib libpng` -lm
+BUILD_LDFLAGS += `$(BUILD_PKG_CONFIG) --libs zlib`
 
 TILE_OBJS  = tile_creator.o
 PAK_OBJS   = pak_creator.o
@@ -111,8 +118,11 @@ makefile.dep : src/*/*.h src/*.h
 	for i in src/*.c src/*/*.c; do $(CC) $(CFLAGS) -MM "$${i}"; done > $@
 
 # compiling other source files.
-$(MAIN_OBJS) $(CORE_OBJS) $(EDIT_OBJS) $(TITLE_OBJS) $(PAK_OBJS) $(PO_OBJS) $(TILE_OBJS):
+$(MAIN_OBJS) $(CORE_OBJS) $(EDIT_OBJS) $(TITLE_OBJS) $(PO_OBJS) $(TILE_OBJS):
 	$(CC) $(CFLAGS) $(DEFINES) -c $<
+
+$(PAK_OBJS):
+	$(BUILD_CC) $(BUILD_CFLAGS) $(DEFINES) -c $<
 
 %.mo: %.po
 	msgfmt -c -o $@ $<
@@ -127,7 +137,7 @@ $(ED_PROG): $(EDIT_OBJS) $(CORE_OBJS)
 
 # linking the program.
 $(PAK_PROG): $(PAK_OBJS)
-	$(CC) $(PAK_OBJS) -o $(PAK_PROG) $(LDFLAGS)
+	$(BUILD_CC) $(PAK_OBJS) -o $(PAK_PROG) $(BUILD_LDFLAGS)
 
 # linking the program.
 $(PO_PROG): $(PO_OBJS)

--- a/src/pak_creator.c
+++ b/src/pak_creator.c
@@ -17,7 +17,13 @@ along with this program; if not, write to the Free Software
 Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
 */
 
-#include "headers.h"
+#include <dirent.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <zlib.h>
+#include "defs.h"
+#include "system/pak_data.h"
 
 FILE *pak;
 int fileID;

--- a/src/structs.h
+++ b/src/structs.h
@@ -18,6 +18,7 @@ Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
 */
 
 #include "defs.h"
+#include "system/pak_data.h"
 
 typedef struct Texture
 {
@@ -333,12 +334,6 @@ typedef struct Grid
 	EntityList listHead;
 	struct Grid *next;
 } Grid;
-
-typedef struct FileData
-{
-	char filename[MAX_FILE_LENGTH];
-	int32_t fileSize, compressedSize, offset;
-} FileData;
 
 typedef struct ContinueData
 {

--- a/src/system/pak_data.h
+++ b/src/system/pak_data.h
@@ -1,0 +1,23 @@
+/*
+Copyright (C) 2025 Parallel Realities
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110-1335, USA.
+*/
+
+typedef struct FileData {
+  char filename[MAX_FILE_LENGTH];
+  int32_t fileSize, compressedSize, offset;
+} FileData;


### PR DESCRIPTION
Trying to cross-compile the project fails because makefile assumes that it can create executables for the build machine using `$(CC)` thus using it to create `./pak`. This PR introduces the `BUILD_CC` and related variables so that they can be set appropriately, e.g.,
```shell
make CC=x86_64-unknown-linux-gnu-gcc HOST_CC=gcc
```
It also reduces the included headers of the `pak_creator.c`, otherwise build system would also need the SDL2 libs despite not using them. `sdl2-config` was replaced with more generic `pkg-config` to capture the dependencies correctly in case they are in a nonstandard location.